### PR TITLE
build: fix GoReleaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,6 @@ jobs:
         if: "!startsWith(github.ref, 'refs/tags/v')"
         with:
           version: latest
-          args: release --skip=publish --skip=validate
+          args: release --clean --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,6 @@
 # go releaser yaml file
+version: 2
+
 env:
   - CGO_ENABLED=0
   - PACKER_PROTOCOL_VERSION=x5.0


### PR DESCRIPTION
The --snapshot flag already adds the skips:

>Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts (implies --skip=announce,publish,validate)